### PR TITLE
Fixes fabric8-launcher/launcher-booster-catalog-service#26: YAML values with ! are treated as tags

### DIFF
--- a/circuit-breaker/common.yaml
+++ b/circuit-breaker/common.yaml
@@ -1,2 +1,2 @@
 metadata:
-  runsOn: !starter
+  runsOn: "!starter"

--- a/crud/common.yaml
+++ b/crud/common.yaml
@@ -1,2 +1,2 @@
 metadata:
-  runsOn: !starter
+  runsOn: "!starter"

--- a/rest-http-secured/common.yaml
+++ b/rest-http-secured/common.yaml
@@ -1,2 +1,2 @@
 metadata:
-  runsOn: !starter
+  runsOn: "!starter"


### PR DESCRIPTION
This fixes https://github.com/fabric8-launcher/launcher-booster-catalog-service/issues/26